### PR TITLE
Define missing variables.

### DIFF
--- a/override/controllers/admin/AdminCustomersController.php
+++ b/override/controllers/admin/AdminCustomersController.php
@@ -230,6 +230,8 @@ class AdminCustomersController extends AdminCustomersControllerCore
     public function ajaxProcessSearchCustomers()
     {
         global $cookie;
+        $context = Context::getContext();
+        $profileID = $context->employee->id_profile;
         $CustRay = array();
         if ($profileID == 1){
             $sql = 'SELECT * FROM '._DB_PREFIX_.'personalsalesmen';


### PR DESCRIPTION
Variable $profileID is used without being assigned any value.